### PR TITLE
Add AGENTS.md and WORKING_STATE.md documentation files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+## Read This First
+
+Before changing behavior, read `README.md` and `docs/WORKING_STATE.md`. Treat this file as the stable repo guide and `docs/WORKING_STATE.md` as the current handoff snapshot.
+
+## Mission
+
+NemotronOS is a hackathon MVP for a local, private, voice-controlled PC agent. The team is building on macOS right now, but the MVP target is Windows in the next few hours, so the current code intentionally keeps the core flow platform-light while the real Windows/Desktop pieces are still being swapped in.
+
+## Repo Map
+
+- `apps/agent-server/nemotronos_agent/main.py`
+  - FastAPI entrypoint for task creation, approvals, event listing, and health.
+- `apps/agent-server/nemotronos_agent/coordinator.py`
+  - Main task orchestration and approval flow.
+- `apps/agent-server/nemotronos_agent/model_client.py`
+  - Mock-first tool planning. In practice, the mock path mainly supports the Downloads organization demo.
+- `apps/tool-server/nemotronos_tools/main.py`
+  - FastAPI tool host.
+- `apps/tool-server/nemotronos_tools/registry.py`
+  - Actual tool registration. Use this, not just tool definitions, to understand what is callable.
+- `apps/tool-server/nemotronos_tools/tools/filesystem.py`
+  - The real MVP slice: dry-run file organization plan, apply flow, and undo log generation.
+- `apps/dashboard/src/App.jsx`
+  - Main dashboard entrypoint for task submission, approval, and event polling.
+- `sandbox/fake_windows_home`
+  - Fake Windows filesystem used during macOS development.
+
+## Current Vertical Slice
+
+The only fully-shaped demo flow today is:
+
+1. A user submits a task from the dashboard or `POST /tasks`.
+2. The agent server creates a task and starts background processing.
+3. The model client chooses `fs_plan_changes` for the Downloads organization prompt.
+4. The tool server maps `C:\Users\Raed\Downloads` into `sandbox/fake_windows_home/Users/Raed/Downloads`.
+5. `fs_plan_changes` builds a dry-run move plan grouped by file type.
+6. The policy engine classifies `fs_apply_changes` as medium risk and requires approval.
+7. After approval, `fs_apply_changes` applies the moves and writes an undo log under `C:\.nemotronos\undo_logs`.
+
+If you are changing behavior outside that path, verify it in code first. Do not assume the rest of the advertised surface is equally implemented.
+
+## Rules For Agents
+
+- Read `README.md` and `docs/WORKING_STATE.md` before making non-trivial changes.
+- Verify repo facts from source code, not from stale docs or inferred architecture.
+- Update `docs/WORKING_STATE.md` whenever behavior, blockers, priorities, or operating assumptions change.
+- Keep docs high signal. Replace stale bullets instead of appending a running diary.
+- Distinguish source from generated artifacts. `__pycache__`, `dist`, and `*.egg-info` are present in the repo and are not the source of truth.
+- Prefer small, targeted edits over broad cleanup during the hackathon window unless cleanup unblocks the current MVP.
+
+## Current Constraints
+
+- State is in memory. Tasks, events, approvals, and stored plans do not survive restarts.
+- The model layer is mock-first. The mock client reliably handles the Downloads organization path and falls back to a simple notification for unsupported goals.
+- The filesystem demo uses a fake Windows root, not a real Windows machine yet.
+- The tool surface is only partially real:
+  - `fs_plan_changes` and `fs_apply_changes` are the most complete tools.
+  - `screen_capture`, `shell_run`, and `notify_user` exist, but they are still mock/stub behavior in `TOOL_MODE=mock_windows`.
+  - Several tool definitions advertised by the agent are not registered by the tool server yet.
+- The real Windows desktop backend is scaffolded, but `WindowsDesktopBackend.capture_screen()` still raises `NotImplementedError`.
+
+## Doc Maintenance
+
+Keep this file stable and process-oriented. Put time-sensitive status, blockers, and next actions in `docs/WORKING_STATE.md`.

--- a/docs/WORKING_STATE.md
+++ b/docs/WORKING_STATE.md
@@ -1,0 +1,57 @@
+# WORKING_STATE.md
+
+Last updated: 2026-05-02
+
+Purpose: current operational snapshot for any teammate or AI agent joining mid-hackathon. Keep this short, current, and action-oriented.
+
+## Current System Status
+
+- The repo has a working macOS development slice for a Windows-first PC agent demo.
+- The main demo is: organize Downloads by file type, show the plan first, require approval, then apply changes.
+- The stack is split into a FastAPI agent server, a FastAPI tool server, and a React dashboard.
+
+## What Works Now
+
+- `POST /tasks` creates a task and starts async processing in the agent server.
+- The mock model can route the Downloads-organization prompt into `fs_plan_changes`.
+- The tool server can build a dry-run file organization plan against the fake Windows Downloads folder.
+- The policy engine marks `fs_apply_changes` as medium risk and the dashboard exposes approval.
+- Approved plans can be applied and generate an undo log.
+- The dashboard can submit tasks, poll health/tasks/events, show the plan preview, and send approval.
+
+## What Is Stubbed Or Fake
+
+- The fake Windows filesystem under `sandbox/fake_windows_home` is the active environment, not a real Windows box.
+- The mock model does not behave like a general agent yet. It mainly supports the Downloads-organization path and otherwise falls back to `notify_user`.
+- `screen_capture` is mock output in `TOOL_MODE=mock_windows`.
+- `shell_run` is a safe stub in `TOOL_MODE=mock_windows`; it does not execute real shell commands there.
+- The real Windows desktop backend is not implemented yet. `WindowsDesktopBackend.capture_screen()` raises `NotImplementedError`.
+- The agent advertises more tool definitions than the tool server currently registers. Treat `apps/tool-server/nemotronos_tools/registry.py` as the runtime truth.
+
+## Highest-Priority Next Tasks
+
+1. Validate the full startup flow on a real Windows machine once the team switches over.
+2. Decide which tools are actually in scope for the MVP and align tool definitions with registered runtime behavior.
+3. Expand beyond the single Downloads demo path only if the main Windows demo is already stable.
+4. Remove or clearly quarantine generated artifacts from active source review if they start causing confusion during the hackathon.
+
+## Windows Handoff Notes
+
+- Current path assumptions are Windows-style at the agent/tool boundary and local sandbox paths underneath.
+- The real user path for the demo is modeled as `C:\Users\Raed\Downloads`.
+- `TOOL_MODE=mock_windows` is the safe current dev path.
+- Switching to real Windows behavior will require replacing or extending the scaffolded desktop/tool backends, not just changing docs or prompts.
+- Check Python 3.11+ and Node/Vite startup on Windows before promising demo readiness.
+
+## Known Mismatches And Risks
+
+- `README.md` tells developers to copy `.env.example`, but `.env.example` is not present in the repo.
+- State is in memory, so restarts wipe tasks, events, approval state, and stored plans.
+- The repo includes committed `__pycache__`, `dist`, and `*.egg-info` artifacts. They should not be treated as the canonical implementation.
+- The broader tool list in `apps/agent-server/nemotronos_agent/tool_defs.py` can make the system look more complete than the runtime actually is.
+
+## Update Protocol
+
+- Replace stale bullets instead of appending status history.
+- Keep next actions ordered by what the next contributor should do first.
+- Record blockers only when they immediately affect the next contributor.


### PR DESCRIPTION
Introduce two new documentation files to provide guidance on the project's structure and current operational status. AGENTS.md serves as a stable guide for understanding the system's components and rules for agents, while WORKING_STATE.md offers a snapshot of the current system status, functionality, and next tasks during the hackathon. These documents aim to enhance clarity and facilitate collaboration among team members.